### PR TITLE
為Unity的檔案在git上設定Smart Merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+#* text=auto
+*.unity binary
+*.prefab binary
+*.asset binary

--- a/Magic-Origin.sln
+++ b/Magic-Origin.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AstarPathfindingProject", "AstarPathfindingProject.csproj", "{B415B1B4-DC57-7985-E3A7-F6B381950ED3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AstarPathfindingProject", "AstarPathfindingProject.csproj", "{52BD2F23-C23F-17CE-EDC8-5BB75FEE1912}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{72286C18-629B-491F-A59B-C3ED59DC9F84}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{95DFB066-5FC9-7F99-E11E-A94A311E9695}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AstarPathfindingProjectEditor", "AstarPathfindingProjectEditor.csproj", "{E91774DC-F3E4-2AD0-C569-E576618D9F7A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AstarPathfindingProjectEditor", "AstarPathfindingProjectEditor.csproj", "{C341B582-AE46-5716-1AE2-51B56ABC19E6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageToolsEditor", "PackageToolsEditor.csproj", "{93CBA961-1AAD-6436-A70D-A20767325F0E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageToolsEditor", "PackageToolsEditor.csproj", "{BABC4C97-8888-2D1B-3C14-69D1DBA61455}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,22 +15,22 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B415B1B4-DC57-7985-E3A7-F6B381950ED3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B415B1B4-DC57-7985-E3A7-F6B381950ED3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B415B1B4-DC57-7985-E3A7-F6B381950ED3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B415B1B4-DC57-7985-E3A7-F6B381950ED3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{72286C18-629B-491F-A59B-C3ED59DC9F84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{72286C18-629B-491F-A59B-C3ED59DC9F84}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{72286C18-629B-491F-A59B-C3ED59DC9F84}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{72286C18-629B-491F-A59B-C3ED59DC9F84}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E91774DC-F3E4-2AD0-C569-E576618D9F7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E91774DC-F3E4-2AD0-C569-E576618D9F7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E91774DC-F3E4-2AD0-C569-E576618D9F7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E91774DC-F3E4-2AD0-C569-E576618D9F7A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{93CBA961-1AAD-6436-A70D-A20767325F0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{93CBA961-1AAD-6436-A70D-A20767325F0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{93CBA961-1AAD-6436-A70D-A20767325F0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{93CBA961-1AAD-6436-A70D-A20767325F0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52BD2F23-C23F-17CE-EDC8-5BB75FEE1912}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52BD2F23-C23F-17CE-EDC8-5BB75FEE1912}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52BD2F23-C23F-17CE-EDC8-5BB75FEE1912}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52BD2F23-C23F-17CE-EDC8-5BB75FEE1912}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95DFB066-5FC9-7F99-E11E-A94A311E9695}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95DFB066-5FC9-7F99-E11E-A94A311E9695}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95DFB066-5FC9-7F99-E11E-A94A311E9695}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95DFB066-5FC9-7F99-E11E-A94A311E9695}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C341B582-AE46-5716-1AE2-51B56ABC19E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C341B582-AE46-5716-1AE2-51B56ABC19E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C341B582-AE46-5716-1AE2-51B56ABC19E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C341B582-AE46-5716-1AE2-51B56ABC19E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BABC4C97-8888-2D1B-3C14-69D1DBA61455}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BABC4C97-8888-2D1B-3C14-69D1DBA61455}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BABC4C97-8888-2D1B-3C14-69D1DBA61455}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BABC4C97-8888-2D1B-3C14-69D1DBA61455}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
因為有些Unity的檔案無法被版控，例如scene，所以當很多人要編輯同一個scene的時候，merge總是會出問題。還好，利用Unity提供的一些功能，我們還是有方法可以將這些檔案納入版控。